### PR TITLE
Add 1.31 version

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -10,8 +10,9 @@
         inherit (pkgs.callPackage ./k0s/default.nix {})
           k0s_1_27
           k0s_1_28
-          k0s_1_30;
-        k0s = k0s_1_30;
+          k0s_1_30
+          k0s_1_31;
+        k0s = k0s_1_31;
       };
 
     in

--- a/k0s/1_31.nix
+++ b/k0s/1_31.nix
@@ -1,0 +1,17 @@
+rec {
+  version = "v1.31.1+k0s.1";
+  srcs = {
+    armv7l-linux = {
+      url = "https://github.com/k0sproject/k0s/releases/download/v1.31.1+k0s.1/k0s-v1.31.1+k0s.1-arm";
+      hash = "sha256-6sBRVu/2j7DX6TShHxNXc3hRlNpGQdcv0T8ThAZa8zM=";
+    };
+    aarch64-linux = {
+      url = "https://github.com/k0sproject/k0s/releases/download/v1.31.1+k0s.1/k0s-v1.31.1+k0s.1-arm64";
+      hash = "sha256-ua1fx5o13ei8eujDuDUuRTfrNvqwjlRM3ODviABLp4U=";
+    };
+    x86_64-linux = {
+      url = "https://github.com/k0sproject/k0s/releases/download/v1.31.1+k0s.1/k0s-v1.31.1+k0s.1-amd64";
+      hash = "sha256-mhL8Qg0Jy3dkJ7TIA78rBEWzTQUXsFRzJKnJprNRjGg=";
+    };
+  };
+}

--- a/k0s/default.nix
+++ b/k0s/default.nix
@@ -11,6 +11,7 @@ let
     k0s_1_27 = import ./1_27.nix;
     k0s_1_28 = import ./1_28.nix;
     k0s_1_30 = import ./1_30.nix;
+    k0s_1_31 = import ./1_31.nix;
   };
 in
 builtins.mapAttrs


### PR DESCRIPTION
Proposing the addition of the 1.31 version of k8s & k0s.
I tested and updated the hash of all URLs using `nix hash to-sri --type sha256 $(nix-prefetch-url https://github.com/k0sproject/k0s/releases/download/v1.31.1+k0s.1/k0s-v1.31.1+k0s.1-amd64)` (example for amd64).
I successfully updated my [personal cluster](https://github.com/cterence/nixos-config/commit/d378ba2fb26b58fef22873cd3f2bfa08cb2e83c3) to the new version with fork of this flake.
Don't hesitate if you have any feedback :)