### PR TITLE
test: adds a basic integration test

### DIFF
--- a/.github/workflows/nixos-test.yml
+++ b/.github/workflows/nixos-test.yml
@@ -1,0 +1,17 @@
+name: nixos-tests
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+  push:
+   branches:
+     - main
+
+jobs:
+  nixos-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: DeterminateSystems/nix-installer-action@main
+      - run: |
+          nix flake check -L

--- a/flake.nix
+++ b/flake.nix
@@ -7,12 +7,8 @@
     let
 
       genPackages = pkgs: rec {
-        inherit (pkgs.callPackage ./k0s/default.nix {})
-          k0s_1_27
-          k0s_1_28
-          k0s_1_30
-          k0s_1_31
-          k0s_1_32;
+        inherit (pkgs.callPackage ./k0s/default.nix { })
+          k0s_1_27 k0s_1_28 k0s_1_30 k0s_1_31 k0s_1_32;
         k0s = k0s_1_32;
       };
 
@@ -33,7 +29,11 @@
         in {
           basic = pkgs.testers.runNixOSTest {
             imports = [ ./tests/basic.nix ];
-            node = { specialArgs = { inherit self; }; };
+            node = { pkgsReadOnly = false; };
+            defaults = {
+              imports = [ self.nixosModules.default ];
+              nixpkgs.overlays = [ self.overlays.default ];
+            };
           };
         });
 

--- a/tests/basic.nix
+++ b/tests/basic.nix
@@ -1,0 +1,24 @@
+{
+  name = "basic";
+  nodes = {
+    node1 = { self, pkgs, ... }: {
+      imports = [ self.nixosModules.default ];
+
+      # runNixOSTest makes nixpkgs.* readonly, so we can't use this:
+      # nixpkgs.overlays = [ self.overlays.default ];
+
+      services.k0s = {
+        enable = true;
+        package = (pkgs.extend self.overlays.default).k0s;
+        spec.api = {
+          address = "192.0.2.1";
+          sans = [ "192.0.2.1" ];
+        };
+      };
+    };
+  };
+  testScript = ''
+    start_all()
+    node1.wait_for_unit("k0scontroller")
+  '';
+}


### PR DESCRIPTION
Run with `nix flake check -L`

Inspired from https://blog.thalheim.io/2023/01/08/how-to-use-nixos-testing-framework-with-flakes/

It uses `runNixOSTest` instead of `runTest`, not sure what's the preferred way to do this. One consequence of using `runNixOSTest` is that it makes `nixpkgs.*` readonly in the node's configuration, which prevents adding the overlay.