### PR TITLE
test: adds test to assert graceful shutdown works

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -27,7 +27,8 @@
       checks = forAllSystems (system:
         let
           pkgs = nixpkgs.legacyPackages.${system};
-          forAllTests = lib.genAttrs [ "single" "ctrl-wrkr" ];
+          forAllTests =
+            lib.genAttrs [ "single" "ctrl-wrkr" "graceful-shutdown" ];
         in forAllTests (test:
           pkgs.testers.runNixOSTest {
             imports = [ ./tests/${test}.nix ];

--- a/tests/graceful-shutdown.nix
+++ b/tests/graceful-shutdown.nix
@@ -1,0 +1,40 @@
+{
+  name = "basic";
+  nodes = {
+    node1 = { config, ... }: {
+      services.k0s = {
+        enable = true;
+        role = "single";
+        spec = {
+          api = {
+            address = config.networking.primaryIPAddress;
+            sans = [ config.networking.primaryIPAddress ];
+          };
+          workerProfiles = [{
+            name = "default";
+            values = {
+              shutdownGracePeriod = "30s";
+              shutdownGracePeriodCriticalPods = "10s";
+            };
+          }];
+        };
+      };
+
+    };
+  };
+  testScript = { nodes }:
+    let k0s = nodes.node1.services.k0s.package;
+    in ''
+      start_all()
+      node1.wait_for_unit("k0scontroller")
+      node1.wait_for_file("/run/k0s/status.sock")
+      node1.succeed("${k0s}/bin/k0s status")
+
+      # we cannot wait for the node to be Ready because it requires access to the internet to download some containers and OpenAPI specs.
+      #   so instead, we just wait until the node is created, which means the kubelet process is running
+      node1.wait_until_succeeds(r"""${k0s}/bin/k0s kubectl wait --for=create nodes/node1""")
+
+      # Assert that it has registered itself to inhibit systemd shutdown
+      node1.succeed("systemd-inhibit --list --no-legend | grep \"kubelet.*shutdown\"")
+    '';
+}


### PR DESCRIPTION
Documentation about this feature is [here](https://kubernetes.io/docs/concepts/cluster-administration/node-shutdown/)

Note that enabling this only works when the node is initialized the first time. It looks as though the `kubelet.yaml` configuration file is only created when the worker is created initially, so modifying the values in `workerProfile` is not reflected until a new worker is created for that profile.

For this reason, it might be a good idea to either turn this on by default or make it more prominent in the config like `k3s` does [here](https://github.com/NixOS/nixpkgs/blob/1d3aeb5a193b9ff13f63f4d9cc169fb88129f860/nixos/modules/services/cluster/k3s/default.nix#L391)