### PR TITLE
Support dual-stack for kuberouter

### DIFF
--- a/nixos/network.nix
+++ b/nixos/network.nix
@@ -58,29 +58,37 @@ in {
       default = {};
     });
 
-    dualStack = optionalAttrs (config.provider == "calico" && config.calico.mode == "bird") {
-      enabled = mkEnableOption "Defines whether or not IPv4/IPv6 dual-stack networking should be enabled.";
-
-      IPv6podCIDR = util.mkOptionMandatoryIf config.dualStack.enabled {
-        description = ''
-          IPv6 Pod network CIDR to use in the cluster.
+    dualStack =
+      optionalAttrs (
+        config.provider
+        == "kuberouter"
+        || (config.provider == "calico" && config.calico.mode == "bird")
+      ) {
+        enabled = mkEnableOption ''
+          Defines whether or not IPv4/IPv6 dual-stack networking should be enabled.
+          With Calico, dual stack only works in bird mode.
         '';
-        type =
-          if config.dualStack.enabled
-          then customTypes.cidrV6
-          else str;
-      } "";
 
-      IPv6serviceCIDR = util.mkOptionMandatoryIf config.dualStack.enabled {
-        description = ''
-          IPv6 Network CIDR to use for cluster VIP services.
-        '';
-        type =
-          if config.dualStack.enabled
-          then customTypes.cidrV6
-          else str;
-      } "";
-    };
+        IPv6podCIDR = util.mkOptionMandatoryIf config.dualStack.enabled {
+          description = ''
+            IPv6 Pod network CIDR to use in the cluster.
+          '';
+          type =
+            if config.dualStack.enabled
+            then customTypes.cidrV6
+            else str;
+        } "";
+
+        IPv6serviceCIDR = util.mkOptionMandatoryIf config.dualStack.enabled {
+          description = ''
+            IPv6 Network CIDR to use for cluster VIP services.
+          '';
+          type =
+            if config.dualStack.enabled
+            then customTypes.cidrV6
+            else str;
+        } "";
+      };
 
     kubeProxy = mkOption {
       description = "Defines the configuration for kube-proxy.";


### PR DESCRIPTION
This resolves #25.

I don't know much about writing NixOS-modules but maybe we should also switch to assertions for validation.
Earlier, when I tried to configure dual-stack, I got pretty frustrated because I couldn't see what the problem was at first. Assertions could help with that. I'll create an issue for discussion, I guess.

We should also take a look if anything else has changed since writing the module. If I find the time, I can check, but if anyone else would like to, feel free.