### PR TITLE
Calico add hostNetwork option

### DIFF
--- a/nixos/calico.nix
+++ b/nixos/calico.nix
@@ -12,6 +12,7 @@ let
     port
     ints
     addCheck
+    bool
     ;
   util = import ./util.nix args;
 in
@@ -39,6 +40,16 @@ in
         "Never"
       ]) (v: config.mode == "vxlan" || v != "Never");
       default = "Always";
+    };
+
+    hostNetwork = mkOption {
+      description = ''
+        Whether to run calico-node pods in host-network mode.
+        Setting this to `true` is the standard configuration and is required
+        to prevent CNI initialization deadlocks on some systems.
+      '';
+      type = bool;
+      default = true; # Default to `true` as it's the recommended and safest setting.
     };
 
     vxlanPort = mkOption {

--- a/tests/calico-host-network.nix
+++ b/tests/calico-host-network.nix
@@ -1,0 +1,34 @@
+# This file tests that the `hostNetwork` option for Calico is correctly
+# processed and rendered into the final k0s configuration file.
+{ pkgs, ... }:
+
+{
+  name = "k0s-calico-host-network";
+  meta.maintainers = [ ]; # You can add your GitHub handle here if you like
+
+  nodes.machine = { pkgs, ... }: {
+    services.k0s = {
+      enable = true;
+      role = "single"; # A single node is sufficient for this config check
+      spec = {
+        network = {
+          provider = "calico";
+          calico.hostNetwork = true; # <-- The new option we are testing
+        };
+      };
+    };
+  };
+
+  # The test script that runs inside the virtual machine.
+  testScript = ''
+    start_all()
+    machine.wait_for_unit("k0s.service")
+
+    # The test succeeds if the generated k0s.yaml contains the expected line.
+    # We use `yq` (which is available in the test environment) to parse the YAML
+    # and check the value, which is more robust than using grep.
+    machine.succeed(
+      "${pkgs.yq-go}/bin/yq -e '.spec.network.calico.hostNetwork == true' /etc/k0s/k0s.yaml"
+    )
+  '';
+}


### PR DESCRIPTION
This adds the `hostNetwork` option to the Calico module.

The Calico CNI can get into a startup deadlock where the `calico-node` pod fails to start because its CNI network can't be set up. This happens because the CNI plugin itself needs a `/var/lib/calico/nodename` file, which the `calico-node` pod is supposed to create.

Setting `hostNetwork: true` on the `calico-node` DaemonSet is the standard upstream solution to break this cycle.

This change exposes that option so users can configure Calico correctly and avoid this race condition declaratively.

https://github.com/johbo/k0s-nix/issues/32